### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ None
 | ```wp_cli_phar_url``` | ```https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar``` | Location of the WP-CLI phar to download |
 | ```wp_cli_bin_path``` | ```/usr/bin/{{ wp_cli_bin_command }}``` | Location to store WP-CLI on remote machine |
 | ```wp_cli_bin_command``` | wp | WP-CLI Coomand on remote machine |
-| ```wp_cli_package```  |  | List of WP-CLI Packege for Installing |
+| ```wp_cli_package```  |  | List of WP-CLI packages for Installing |
 
 ## Dependencies
 


### PR DESCRIPTION
Fixed typo, since wp_cli_package can be a list, it would also probably make sense to rename this variable to "wp_cli_packages"