### PR TITLE
Rename wp_cli_package to wp_cli_packages and correct typo's

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ None
 | ```wp_cli_phar_url``` | ```https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar``` | Location of the WP-CLI phar to download |
 | ```wp_cli_bin_path``` | ```/usr/bin/{{ wp_cli_bin_command }}``` | Location to store WP-CLI on remote machine |
 | ```wp_cli_bin_command``` | wp | WP-CLI Coomand on remote machine |
-| ```wp_cli_package```  |  | List of WP-CLI Packege for Installing |
+| ```wp_cli_packages```  |  | List of WP-CLI packages for Installing |
 
 ## Dependencies
 
@@ -45,7 +45,7 @@ None
 
 ### 1.2
 
-* add WP-CLI packege installer
+* add WP-CLI package installer
 
 ### 1.1
 
@@ -66,4 +66,4 @@ This project is under the MIT License. See the [LICENSE](https://sbaerlo.ch/lice
 
 ## Copyright
 
-(c) 20186, Simon Bärlocher
+(c) 2018, Simon Bärlocher

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@
 wp_cli_phar_url: https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 wp_cli_bin_path: "/usr/bin/{{ wp_cli_bin_command }}"
 wp_cli_bin_command: wp
-wp_cli_package: []
+wp_cli_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,12 @@
   tags:
     - packages
 
-- name: Install WP-CLI Packets
+- name: Install WP-CLI Packages
   command: "{{ wp_cli_bin_command }} package install {{ item }}"
   register: command_result
   changed_when: "'Installing package' in command_result.stdout"
   when: item is defined
   with_items:
-    - "{{ wp_cli_package }}"
+    - "{{ wp_cli_packages }}"
   tags:
     - packages


### PR DESCRIPTION
I renamed the wp_cli_package variable to wp_cli_packages through out the role as it better reflects the fact that it is a list.

I also corrected numerous typo's.